### PR TITLE
Using | as separator.

### DIFF
--- a/main.py
+++ b/main.py
@@ -32,8 +32,7 @@ class KeywordQueryEventListener(EventListener):
 
         # get directories from preferences
         if extension.preferences.get('directory_list') is not None:
-            directories = [x.strip() for x in extension.preferences['directory_list'].split(
-                ',')]
+            directories = [x.strip() for x in extension.preferences['directory_list'].split(',')]
 
             # giv user feedback if no directory has been specified
             if len(directories) == 0:
@@ -43,15 +42,22 @@ class KeywordQueryEventListener(EventListener):
                                                  on_enter=ExtensionCustomAction("none", keep_app_open=True)))
                 return RenderResultListAction(items)
 
+            # load alias for directories
+            aliases = {}
+            for dir_path in directories:
+                alias = extension.preferences.get(f"alias_{dir_path}")
+                if alias:
+                    aliases[dir_path] = alias
+
         if arg is not None and len(arg) > 0:
             directories = [x for x in directories if arg.lower() in x.lower()]
 
         for i in range(len(directories)):
-            key = directories[i]
-            data = directories[i]
+            dir_path = directories[i]
+            alias = aliases.get(dir_path, dir_path) 
             items.append(ExtensionResultItem(icon='images/dir.png',
-                                             name="Open %s" % key,
-                                             on_enter=ExtensionCustomAction(data, keep_app_open=False)))
+                                             name="Open {alias}",
+                                             on_enter=ExtensionCustomAction(dir_path, keep_app_open=False)))
 
         return RenderResultListAction(items)
 

--- a/main.py
+++ b/main.py
@@ -32,7 +32,8 @@ class KeywordQueryEventListener(EventListener):
 
         # get directories from preferences
         if extension.preferences.get('directory_list') is not None:
-            directories = [x.strip() for x in extension.preferences['directory_list'].split(',')]
+            directories = [x.strip() for x in extension.preferences['directory_list'].split(
+                ',')]
 
             # giv user feedback if no directory has been specified
             if len(directories) == 0:
@@ -42,22 +43,20 @@ class KeywordQueryEventListener(EventListener):
                                                  on_enter=ExtensionCustomAction("none", keep_app_open=True)))
                 return RenderResultListAction(items)
 
-            # load alias for directories
-            aliases = {}
-            for dir_path in directories:
-                alias = extension.preferences.get(f"alias_{dir_path}")
-                if alias:
-                    aliases[dir_path] = alias
-
         if arg is not None and len(arg) > 0:
             directories = [x for x in directories if arg.lower() in x.lower()]
 
-        for i in range(len(directories)):
-            dir_path = directories[i]
-            alias = aliases.get(dir_path, dir_path) 
+        for directory in directories:
+            # Split the directory entry into path and alias
+            path, alias = directory.split("|") if "|" in directory else (directory, directory)
+
+            # Replace tilde with home directory path
+            path = os.path.expanduser(path)
+
+            # Append the item with the alias
             items.append(ExtensionResultItem(icon='images/dir.png',
-                                             name="Open {alias}",
-                                             on_enter=ExtensionCustomAction(dir_path, keep_app_open=False)))
+                                             name=f"Open {alias}",
+                                             on_enter=ExtensionCustomAction(path, keep_app_open=False)))
 
         return RenderResultListAction(items)
 

--- a/manifest.json
+++ b/manifest.json
@@ -35,12 +35,5 @@
       "description": "List of directories. Format: \"Downloads, Documents\"",
       "default_value": "Downloads"
     }
-    {
-      "id": "alias",
-      "type": "input",
-      "name": "Alias",
-      "description": "Alias for the directory",
-      "default_value": "Alias"
-    }
   ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -35,5 +35,12 @@
       "description": "List of directories. Format: \"Downloads, Documents\"",
       "default_value": "Downloads"
     }
+    {
+      "id": "alias",
+      "type": "input",
+      "name": "Alias",
+      "description": "Alias for the directory",
+      "default_value": ""
+    }
   ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -40,7 +40,7 @@
       "type": "input",
       "name": "Alias",
       "description": "Alias for the directory",
-      "default_value": ""
+      "default_value": "Alias"
     }
   ]
 }


### PR DESCRIPTION
I put | as a separator in the directories configuration to be able to use aliases for the directories instead of having to search for part of the path or the full path.